### PR TITLE
fix(import): remove big svgs from top carousel on main page before import

### DIFF
--- a/tools/importer/import.custom.js
+++ b/tools/importer/import.custom.js
@@ -38,19 +38,14 @@ export const customElements = [];
  * Custom transformer to convert SVGs to PNG images after all other transforms.
  * Replaces each SVG with an <img> using a data URL.
  */
-function svgToPngTransformer(hookName, element, payload) {
-  if (hookName !== 'afterTransform') return;
-  const svgs = element.querySelectorAll('svg');
-  svgs.forEach((svg) => {
-    const serializer = new XMLSerializer();
-    const svgString = serializer.serializeToString(svg);
-    const svgDataUrl = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgString)))}`;
-    const img = svg.ownerDocument.createElement('img');
-    img.src = svgDataUrl;
-    svg.replaceWith(img);
+function removeTopCarouselSVGsTransformer(hookName, element, payload) {
+  if (hookName !== 'beforePageTransform') return;
+  console.log(payload.document);
+  payload.document.querySelectorAll('#w-slider-mask-0 img[src^="data:image/svg"]').forEach((svg) => {
+    svg.remove();
   });
 }
 
 export const customTransformers = {
-  svgToPng: svgToPngTransformer,
+  removeTopCarouselSVGs: removeTopCarouselSVGsTransformer,
 };


### PR DESCRIPTION
@Nichols5973, here is a quick fix to unblock import of the main page. Though this will remove the SVGs from the top carousel.